### PR TITLE
Correction example for httpPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Any of the CLI options can be added to your `serverless.yml`. For example:
 custom:
   serverless-offline-scaleway:
     host: "0.0.0.0"
-    port: 4000
+    httpPort: 4000
     printOutput: true
 ```
 


### PR DESCRIPTION
The `port` variable was not working.
The correct one is: `httpPort`.
I corrected it in the README example :)